### PR TITLE
Update depedency from Flask-Cache to Flask-Caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,14 +92,16 @@ Flask app:
 
 How does this work?  In the background, `flask-heroku-cacheify` is really just
 automatically configuring the popular
-[Flask-Cache](http://pythonhosted.org/Flask-Cache/) extension!  This means, you
+[Flask-Caching](https://pythonhosted.org/Flask-Caching/) extension!  This means, you
 can basically skip down to [this
-part](http://pythonhosted.org/Flask-Cache/#caching-view-functions) of their
+part](https://pythonhosted.org/Flask-Caching/#caching-view-functions) of their
 documentation, and begin using all the methods listed there, without worrying
 about setting up your caches!  Neat, right?
 
 For more information and examples of how to use your cache, don't forget to read
-the [Flask-Cache](http://pythonhosted.org/Flask-Cache/) documentation.
+the [Flask-Cachiny](https://pythonhosted.org/Flask-Caching/) documentation.
+
+*Note: Flask-Heroku-Cacheify was updated in v1.7.0 to depend on Flask-Caching which is an active fork of the now dormant Flask-Cache package.*
 
 
 ## Like This?
@@ -114,6 +116,11 @@ Either way, thanks!  <3
 
 
 ## Changelog
+
+1.7.0: 26-09-2018
+
+    - Update dependency from Flask-Cache to Flask-Caching
+    - Update docs to represent updated dependency
 
 1.6.1: 12-20-2017
 

--- a/flask_cacheify.py
+++ b/flask_cacheify.py
@@ -1,6 +1,6 @@
 from os import environ
 
-from flask_cache import Cache
+from flask_caching import Cache
 
 
 def init_cacheify(app, config=None):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
 
     # Basic package information:
     name = 'Flask-Heroku-Cacheify',
-    version = '1.6.1',
+    version = '1.7.0',
     py_modules = ('flask_cacheify', ),
 
     # Packaging options:
@@ -16,7 +16,7 @@ setup(
 
     # Package dependencies:
     install_requires = [
-        'Flask-Cache>=0.11.1',
+        'Flask-Caching>=1.4.0',
         'pylibmc>=1.2.3',
         'redis>=2.7.2'
     ],


### PR DESCRIPTION
Flask-Cache is apparently dormant, and is not compatible with the latest version of Flask.

This PR updates the depency from Flask-Cache to a fork of the project called Flask-Caching which appears to be more actively maintained.

Resolves #14 

See issue notes for more details about why this is suggested option.